### PR TITLE
Avoid linking full Foundation on Linux; add CI linkage test

### DIFF
--- a/.github/workflows/linkage-test.yml
+++ b/.github/workflows/linkage-test.yml
@@ -1,0 +1,19 @@
+name: linkage-test
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+
+jobs:
+  linkage-test:
+    name: Linkage test
+    runs-on: ubuntu-22.04
+    container: swift:6.1
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Run linkage test
+        shell: bash
+        run: ./scripts/run-linkage-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 .edge-build
 ExampleApp-container.tar
 .worktrees/
+Tests/LinkageTest/Package.resolved

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "79e32da112df6c407ed1c15315d2ab005bf87eef47043524fafc555d5a1604fe",
+  "originHash" : "97fb6e54b37c0e1bcbd6b4d214c23517914f533d50975bfc9c835560dd098c9c",
   "pins" : [
     {
       "identity" : "swift-algorithms",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.26.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
+    .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
   ],
   targets: [
     .target(
@@ -28,6 +29,7 @@ let package = Package(
         .product(name: "NIOExtras", package: "swift-nio-extras"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "Algorithms", package: "swift-algorithms"),
       ]
     ),
     .target(name: "DBusCodegen"),

--- a/Sources/DBUS/DBusAddress.swift
+++ b/Sources/DBUS/DBusAddress.swift
@@ -45,7 +45,7 @@ public enum DBusAddress: Sendable, Equatable {
   /// - Returns: The parsed ``DBusAddress``.
   /// - Throws: ``DBusAddressError`` when the string is empty or malformed.
   public static func parse(_ address: String) throws -> DBusAddress {
-    let trimmed = address.trimmedWhitespace
+    let trimmed = address.trimmingWhitespaces()
     guard !trimmed.isEmpty else {
       throw DBusAddressError.emptyAddress
     }
@@ -111,7 +111,7 @@ public enum DBusAddress: Sendable, Equatable {
   }
 
   private static func parseEntry(_ entry: Substring) throws -> DBusAddress? {
-    let trimmed = entry.trimmedWhitespace
+    let trimmed = entry.trimmingWhitespaces()
     guard !trimmed.isEmpty else { return nil }
 
     let parts = trimmed.split(separator: ":", maxSplits: 1)

--- a/Sources/DBUS/DBusAddress.swift
+++ b/Sources/DBUS/DBusAddress.swift
@@ -45,7 +45,7 @@ public enum DBusAddress: Sendable, Equatable {
   /// - Returns: The parsed ``DBusAddress``.
   /// - Throws: ``DBusAddressError`` when the string is empty or malformed.
   public static func parse(_ address: String) throws -> DBusAddress {
-    let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmed = address.trimmedWhitespace
     guard !trimmed.isEmpty else {
       throw DBusAddressError.emptyAddress
     }
@@ -111,7 +111,7 @@ public enum DBusAddress: Sendable, Equatable {
   }
 
   private static func parseEntry(_ entry: Substring) throws -> DBusAddress? {
-    let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmed = entry.trimmedWhitespace
     guard !trimmed.isEmpty else { return nil }
 
     let parts = trimmed.split(separator: ":", maxSplits: 1)

--- a/Sources/DBUS/DBusAuthMechanism.swift
+++ b/Sources/DBUS/DBusAuthMechanism.swift
@@ -97,12 +97,18 @@ internal enum DBusAuthHash {
 }
 
 internal enum DBusAuthEncoding {
-  static func hexEncode(_ bytes: [UInt8]) -> String {
-    bytes.map { String(format: "%02x", $0) }.joined()
+  static func hexEncode(_ bytes: some Sequence<UInt8>) -> String {
+    let digits = Array("0123456789abcdef".utf8)
+    var out = [UInt8]()
+    for byte in bytes {
+      out.append(digits[Int(byte >> 4)])
+      out.append(digits[Int(byte & 0x0f)])
+    }
+    return String(decoding: out, as: UTF8.self)
   }
 
   static func hexEncode(_ string: String) -> String {
-    hexEncode(Array(string.utf8))
+    hexEncode(string.utf8)
   }
 
   static func hexDecode(_ hex: String) throws -> [UInt8] {
@@ -179,10 +185,10 @@ internal enum DBusAuthCookie {
     switch hash {
     case .sha1:
       let digest = Insecure.SHA1.hash(data: bytes)
-      return digest.map { String(format: "%02x", $0) }.joined()
+      return DBusAuthEncoding.hexEncode(digest)
     case .sha256:
       let digest = SHA256.hash(data: bytes)
-      return digest.map { String(format: "%02x", $0) }.joined()
+      return DBusAuthEncoding.hexEncode(digest)
     }
   }
 

--- a/Sources/DBUS/DBusAuthenticationHandler.swift
+++ b/Sources/DBUS/DBusAuthenticationHandler.swift
@@ -1,3 +1,4 @@
+import Algorithms
 import Logging
 import NIO
 import NIOCore
@@ -9,49 +10,12 @@ import NIOExtras
   import Foundation
 #endif
 
-/// compiler directive that checks if the Darwin framework can be imported.
-/// The Darwin framework is only available on Apple platforms (macOS, iOS, iPadOS, tvOS, watchOS),
-/// so this condition effectively checks if the code is being compiled for a non-Apple platform.
-#if !canImport(Darwin)
-  // Provide CharacterSet and trimmingCharacters implementation for non-Apple platforms
-  extension Character {
-    var isWhitespaceOrNewline: Bool {
-      return self == " " || self == "\t" || self == "\n" || self == "\r"
-    }
+extension StringProtocol {
+  /// Returns the string with leading and trailing whitespace and newlines removed.
+  func trimmingWhitespaces() -> String {
+    String(self.trimming(while: \.isWhitespace))
   }
-
-  public struct CharacterSet: Sendable {
-    let characters: Set<Character>
-
-    static let whitespacesAndNewlines = CharacterSet(characters: [" ", "\t", "\n", "\r"])
-
-    init(characters: [Character]) {
-      self.characters = Set(characters)
-    }
-
-    func contains(_ character: Character) -> Bool {
-      return characters.contains(character)
-    }
-  }
-
-  extension String {
-    func trimmingCharacters(in set: CharacterSet) -> String {
-      var result = self
-
-      // Trim leading characters
-      while !result.isEmpty, let first = result.first, set.contains(first) {
-        result.removeFirst()
-      }
-
-      // Trim trailing characters
-      while !result.isEmpty, let last = result.last, set.contains(last) {
-        result.removeLast()
-      }
-
-      return result
-    }
-  }
-#endif
+}
 
 /// Authentication types supported for D-Bus connections.
 ///
@@ -199,7 +163,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
         logger.trace(
           "Received authentication response",
           metadata: [
-            "response": "\(line.trimmingCharacters(in: .whitespacesAndNewlines))"
+            "response": "\(line.trimmingWhitespaces())"
           ]
         )
 
@@ -209,7 +173,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
             context.fireErrorCaught(DBusAuthenticationError.invalidAuthCommand)
             return
           }
-          let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespacesAndNewlines)
+          let payload = String(line.dropFirst(5)).trimmedWhitespace
           do {
             let response = try currentMechanism.cookieResponse(for: payload)
             let out = context.channel.allocator.buffer(string: response)
@@ -235,7 +199,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
           }
         } else if line.starts(with: "REJECTED") {
           let trimmed = line.dropFirst("REJECTED".count)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmedWhitespace
           let offered = trimmed.isEmpty ? nil : Set(trimmed.split(separator: " ").map(String.init))
           handleRejected(offered: offered, context: context, rawLine: line)
         } else if line.starts(with: "ERROR") {
@@ -244,7 +208,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
           logger.debug(
             "Received unexpected authentication response",
             metadata: [
-              "response": "\(line.trimmingCharacters(in: .whitespacesAndNewlines))"
+              "response": "\(line.trimmingWhitespaces())"
             ]
           )
           state = .failed
@@ -256,7 +220,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
         logger.trace(
           "Received UNIX_FD negotiation response",
           metadata: [
-            "response": "\(line.trimmingCharacters(in: .whitespacesAndNewlines))"
+            "response": "\(line.trimmingWhitespaces())"
           ]
         )
 
@@ -272,7 +236,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
           logger.debug(
             "Received unexpected UNIX_FD negotiation response",
             metadata: [
-              "response": "\(line.trimmingCharacters(in: .whitespacesAndNewlines))"
+              "response": "\(line.trimmingWhitespaces())"
             ]
           )
           state = .failed
@@ -363,7 +327,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
         ])
       sendAuth(for: next, context: context)
     } else {
-      let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+      let trimmed = rawLine.trimmingWhitespaces()
       logger.debug(
         "Authentication rejected by server with no supported mechanisms",
         metadata: [
@@ -394,7 +358,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
       logger.trace(
         "Sending authentication command",
         metadata: [
-          "command": "\(authLine.trimmingCharacters(in: .whitespacesAndNewlines))"
+          "command": "\(authLine.trimmingWhitespaces())"
         ]
       )
     } catch {

--- a/Sources/DBUS/DBusAuthenticationHandler.swift
+++ b/Sources/DBUS/DBusAuthenticationHandler.swift
@@ -173,7 +173,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
             context.fireErrorCaught(DBusAuthenticationError.invalidAuthCommand)
             return
           }
-          let payload = String(line.dropFirst(5)).trimmedWhitespace
+          let payload = String(line.dropFirst(5)).trimmingWhitespaces()
           do {
             let response = try currentMechanism.cookieResponse(for: payload)
             let out = context.channel.allocator.buffer(string: response)
@@ -199,7 +199,7 @@ internal final class DBusAuthenticationHandler: ChannelDuplexHandler, @unchecked
           }
         } else if line.starts(with: "REJECTED") {
           let trimmed = line.dropFirst("REJECTED".count)
-            .trimmedWhitespace
+            .trimmingWhitespaces()
           let offered = trimmed.isEmpty ? nil : Set(trimmed.split(separator: " ").map(String.init))
           handleRejected(offered: offered, context: context, rawLine: line)
         } else if line.starts(with: "ERROR") {

--- a/Tests/DBUSTests/DBusAuthenticationHandlerTests.swift
+++ b/Tests/DBUSTests/DBusAuthenticationHandlerTests.swift
@@ -191,7 +191,7 @@ struct DBusAuthenticationHandlerTests {
     let responseLine = String(buffer: responseBuffer)
     #expect(responseLine.hasPrefix("DATA "), "Expected DATA response")
 
-    let responseHex = responseLine.dropFirst(5).trimmingCharacters(in: .whitespacesAndNewlines)
+    let responseHex = responseLine.dropFirst(5).trimmingWhitespaces()
     let decoded = try DBusAuthEncoding.decodeHexString(responseHex)
     let parts = decoded.split(whereSeparator: \.isWhitespace)
     guard parts.count == 2 else {
@@ -202,9 +202,8 @@ struct DBusAuthenticationHandlerTests {
     let clientChallenge = String(parts[0])
     let digest = String(parts[1])
     let composite = "\(serverChallenge):\(clientChallenge):\(cookieValue)"
-    let expectedDigest = Insecure.SHA1.hash(data: Array(composite.utf8))
-      .map { String(format: "%02x", $0) }
-      .joined()
+    let expectedDigest = DBusAuthEncoding.hexEncode(
+      Insecure.SHA1.hash(data: Array(composite.utf8)))
     #expect(digest == expectedDigest, "Digest should match server challenge and cookie")
 
     try channel.close().wait()

--- a/Tests/LinkageTest/Package.swift
+++ b/Tests/LinkageTest/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "linkage-test",
+  dependencies: [
+    .package(name: "DBUS", path: "../..")
+  ],
+  targets: [
+    .executableTarget(
+      name: "linkageTest",
+      dependencies: [
+        .product(name: "DBUS", package: "DBUS")
+      ]
+    )
+  ]
+)

--- a/Tests/LinkageTest/Sources/linkageTest/main.swift
+++ b/Tests/LinkageTest/Sources/linkageTest/main.swift
@@ -1,0 +1,3 @@
+import DBUS
+
+print("\(DBusClient.self)")

--- a/scripts/run-linkage-test.sh
+++ b/scripts/run-linkage-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eu
+
+# Validate that we're running on Linux
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "Error: This script must be run on Linux. Current OS: $(uname -s)" >&2
+    exit 1
+fi
+
+echo "Running on Linux - proceeding with linkage test..."
+
+# Build the linkage test package
+echo "Building linkage test package..."
+swift build --package-path Tests/LinkageTest
+
+# Construct build path
+build_path=$(swift build --package-path Tests/LinkageTest --show-bin-path)
+binary_path=$build_path/linkageTest
+
+# Verify the binary exists
+if [[ ! -f "$binary_path" ]]; then
+    echo "Error: Built binary not found at $binary_path" >&2
+    exit 1
+fi
+
+echo "Checking linkage for binary: $binary_path"
+
+# Run ldd and check if libFoundation.so is linked
+ldd_output=$(ldd "$binary_path")
+echo "LDD output:"
+echo "$ldd_output"
+
+if echo "$ldd_output" | grep -q "libFoundation.so"; then
+    echo "Error: Binary is linked against libFoundation.so - this indicates incorrect linkage. Ensure the full Foundation is not linked on Linux." >&2
+    exit 1
+else
+    echo "Success: Binary is not linked against libFoundation.so - linkage test passed."
+fi


### PR DESCRIPTION
## Motivation

On Linux, any compiled Swift file with a plain `import Foundation` drags `libFoundation.so`, `libFoundationInternationalization.so`, and `lib_FoundationICU.so` (~30 MB) into the final binary. The DBUS sources already use the `#if canImport(FoundationEssentials)` pattern, but two API usages still forced full Foundation in, and nothing guarded against regressions.

## Changes

**Remove the last full-Foundation dependencies:**
- `trimmingCharacters(in:)` and the Linux `CharacterSet` polyfill are replaced by a small `StringProtocol.trimmingWhitespaces()` helper backed by swift-algorithms' `trimming(while:)` (new dependency: `apple/swift-algorithms`).
- `String(format: "%02x", _:)` hex encoding is replaced by a manual hex encoder over UTF-8 digits, reused for the SHA-1/SHA-256 cookie digests.

**Add a linkage test** (ported from [apple/async-http-client](https://github.com/apple/async-http-client)):
- `Tests/LinkageTest` — a minimal executable package depending on `DBUS`.
- `scripts/run-linkage-test.sh` — builds it and fails if `ldd` shows `libFoundation.so`.
- `.github/workflows/linkage-test.yml` — runs the script on Linux (`swift:6.1` container) for every push/PR, so a future change or dependency bump can't silently re-link full Foundation.

## Testing

- `swift test`: 147 tests in 16 suites pass.
- `swift format lint --recursive --strict Sources` passes.
- `./scripts/run-linkage-test.sh` passes locally: the built binary links `libFoundationEssentials.so` only, no `libFoundation.so`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)